### PR TITLE
refactor: use of new android api slash screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ jspm_packages
 # Optional REPL history
 .node_repl_history
 .idea
+
+# Android/IntelliJ
+.gradle

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,7 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.core:core-splashscreen:1.0.1'
     def supportLibVersion = rootProject.hasProperty('supportLibVersion') ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])

--- a/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
+++ b/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
@@ -1,11 +1,6 @@
 package org.devio.rn.splashscreen;
 
 import android.app.Activity;
-import android.app.Dialog;
-import android.os.Build;
-import android.view.WindowManager;
-
-import java.lang.ref.WeakReference;
 
 /**
  * SplashScreen
@@ -16,92 +11,22 @@ import java.lang.ref.WeakReference;
  * Email:crazycodeboy@gmail.com
  */
 public class SplashScreen {
-    private static Dialog mSplashDialog;
-    private static WeakReference<Activity> mActivity;
-
-    /**
-     * 打开启动屏
-     */
-    public static void show(final Activity activity, final int themeResId, final boolean fullScreen) {
-        if (activity == null) return;
-        mActivity = new WeakReference<Activity>(activity);
-        activity.runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                if (!activity.isFinishing()) {
-                    mSplashDialog = new Dialog(activity, themeResId);
-                    mSplashDialog.setContentView(R.layout.launch_screen);
-                    mSplashDialog.setCancelable(false);
-                    if (fullScreen) {
-                        setActivityAndroidP(mSplashDialog);
-                    }
-                    if (!mSplashDialog.isShowing()) {
-                        mSplashDialog.show();
-                    }
-                }
-            }
-        });
-    }
-
-    /**
-     * 打开启动屏
-     */
-    public static void show(final Activity activity, final boolean fullScreen) {
-        int resourceId = fullScreen ? R.style.SplashScreen_Fullscreen : R.style.SplashScreen_SplashTheme;
-
-        show(activity, resourceId, fullScreen);
-    }
+    private static boolean keep = true;
 
     /**
      * 打开启动屏
      */
     public static void show(final Activity activity) {
-        show(activity, false);
+        if (activity == null) return;
+        androidx.core.splashscreen.SplashScreen splash = androidx.core.splashscreen.SplashScreen.installSplashScreen(activity);
+        splash.setKeepOnScreenCondition(() -> keep);
     }
 
     /**
      * 关闭启动屏
      */
     public static void hide(Activity activity) {
-        if (activity == null) {
-            if (mActivity == null) {
-                return;
-            }
-            activity = mActivity.get();
-        }
-
         if (activity == null) return;
-
-        final Activity _activity = activity;
-
-        _activity.runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                if (mSplashDialog != null && mSplashDialog.isShowing()) {
-                    boolean isDestroyed = false;
-
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                        isDestroyed = _activity.isDestroyed();
-                    }
-
-                    if (!_activity.isFinishing() && !isDestroyed) {
-                        mSplashDialog.dismiss();
-                    }
-                    mSplashDialog = null;
-                }
-            }
-        });
-    }
-
-    private static void setActivityAndroidP(Dialog dialog) {
-        //设置全屏展示
-        if (Build.VERSION.SDK_INT >= 28) {
-            if (dialog != null && dialog.getWindow() != null) {
-                dialog.getWindow().addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);//全屏显示
-                WindowManager.LayoutParams lp = dialog.getWindow().getAttributes();
-                lp.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
-                dialog.getWindow().setAttributes(lp);
-            }
-        }
+        keep = false;
     }
 }

--- a/android/src/main/res/values/refs.xml
+++ b/android/src/main/res/values/refs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <item type="layout" name="launch_screen">
-        @layout/launch_screen
-    </item>
-</resources>

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,12 +1,2 @@
 <resources>
-    <style name="SplashScreen_SplashAnimation">
-        <item name="android:windowExitAnimation">@android:anim/fade_out</item>
-    </style>
-
-    <style name="SplashScreen_SplashTheme" parent="Theme.AppCompat.NoActionBar">
-        <item name="android:windowAnimationStyle">@style/SplashScreen_SplashAnimation</item>
-    </style>
-    <style name="SplashScreen_Fullscreen" parent="SplashScreen_SplashTheme">
-        <item name="android:windowFullscreen">true</item>
-    </style>
 </resources>


### PR DESCRIPTION
This PR is not fully implement due to in some android devices api level 32 (android 12) icon is not displaying first time app is build. This behavior could an API error that is not officially reported or resolved. It was implemented in native android projects, in latest react native project, using default icons, implementing official documentation and in all of them had the same behavior. Even, a beta version was used (implementation("androidx.core:core-splashscreen:1.2.0-alpha02")) and it had not any effects in this situation. 